### PR TITLE
libgsm and openssl detection cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ endif()
 
 # Do we want OpenSSL support or integrated GameSpy SSLv3 engine support?
 option(RS_OPENSSL "Enable OpenSSL support" ON)
+option(RS_HTTPLOG "Enable HTTP logging" OFF)
 
 # This is GameSpy built-in memory managed. I don't know if it needs to be disabled but a test requires it.
 #option(RS_MEM_MANAGED "Enable GameSpy built-in memory manager" ON)
@@ -39,14 +40,6 @@ add_definitions(-DGS_PEER)
 
 if(RS_WINSOCK2)
     add_definitions(-DGSI_WINSOCK2)
-endif()
-
-if (RS_OPENSSL)
-	add_definitions(-DOPENSSL)
-	
-	find_package(OpenSSL REQUIRED)
-	
-	include_directories(${OPENSSL_INCLUDE_DIR})
 endif()
 
 #if (RS_MEM_MANAGED)

--- a/Voice2/CMakeLists.txt
+++ b/Voice2/CMakeLists.txt
@@ -42,6 +42,15 @@ if(RS_BUILD_TESTS)
             set(PLATFORM_INCLUDES ${PLATFORM_INCLUDES} ${DirectX_DSOUND_INCLUDE_DIR})
             set(PLATFORM_LIBRARIES ${PLATFORM_LIBRARIES} ${DirectX_DSOUND_LIBRARY})
         endif()
+
+        # Find libgsm for the voice2bench program.
+        # Appears to only be needed for win32 or psp builds of voice2bench
+        find_package(Gsm)
+
+        if(NOT GSM_FOUND)
+            add_subdirectory(voice2bench/libgsm)
+            set(GSM_LIBRARIES gsm)
+        endif()
     endif()
 
     # If its not UNIX or it is UNIX and is APPLE.
@@ -52,4 +61,8 @@ if(RS_BUILD_TESTS)
         #target_include_directories(voicetest BEFORE PRIVATE ${PLATFORM_INCLUDES})
         #target_compile_definitions(voicetest PRIVATE test_main=main GV_CUSTOM_SOURCE_TYPE=SOCKADDR_IN)
     endif()
+
+    add_executable(voicebench voice2bench/voice2bench.c)
+    target_link_libraries(voicebench rsvoice2 ${PLATFORM_LIBRARIES} ${GSM_LIBRARIES})
+    target_include_directories(voicebench BEFORE PRIVATE ${PLATFORM_INCLUDES})
 endif()

--- a/Voice2/voice2bench/libgsm/CMakeLists.txt
+++ b/Voice2/voice2bench/libgsm/CMakeLists.txt
@@ -1,0 +1,35 @@
+cmake_minimum_required(VERSION 3.1)
+
+project(gsm VERSION 1.0.0 LANGUAGES C)
+
+set(GSM_HEADERS
+    inc/gsm.h
+)
+
+set(GSM_SOURCES 
+    src/add.c
+    src/code.c
+    src/debug.c
+    src/decode.c
+    src/long_term.c
+    src/lpc.c
+    src/preprocess.c
+    src/rpe.c
+    src/gsm_destroy.c
+    src/gsm_decode.c
+    src/gsm_encode.c
+    src/gsm_explode.c
+    src/gsm_implode.c
+    src/gsm_create.c
+    src/gsm_print.c
+    src/gsm_option.c
+    src/short_term.c
+    src/table.c
+)
+
+add_library(gsm STATIC ${GSM_HEADERS} ${GSM_SOURCES})
+target_compile_definitions(gsm PRIVATE -DSASR -DNeedFunctionPrototypes=1)
+target_include_directories(gsm
+	PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc>
+	PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc>
+)

--- a/cmake/FindGsm.cmake
+++ b/cmake/FindGsm.cmake
@@ -1,0 +1,32 @@
+set(_GSM_ROOT_HINTS
+    ${GSM_ROOT_DIR}
+    ENV GSM_ROOT_DIR
+)
+
+find_path(GSM_INCLUDE_DIR NAMES gsm.h ${_GSM_ROOT_HINTS} PATH_SUFFIXES include)
+find_library(GSM_LIBRARY NAMES gsm HINTS ${_GSM_ROOT_HINTS})
+
+if(GSM_INCLUDE_DIR AND GSM_LIBRARY)
+	set(GSM_FOUND TRUE)
+endif()
+
+if(GSM_FOUND)
+	if (NOT Gsm_FIND_QUIETLY)
+		message(STATUS "Found gsm includes:	${GSM_INCLUDE_DIR}/gsm.h")
+		message(STATUS "Found gsm library: ${GSM_LIBRARY}")
+	endif ()
+    
+    if(NOT TARGET GSM::GSM)
+        add_library(GSM::GSM SHARED IMPORTED)
+        set_target_properties(GSM:GSM PROPERTIES
+            INTERFACE_INCLUDE_DIRECTORIES "${GSM_INCLUDE_DIR}"
+            IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+            IMPORTED_LOCATION "${GSM_LIBRARY}")
+    endif()
+    
+    set(GSM_LIBRARIES GSM::GSM)
+else()
+	if (Gsm_FIND_REQUIRED)
+		message(FATAL_ERROR "Could not find gsm development files")
+	endif ()
+endif()

--- a/ghttp/CMakeLists.txt
+++ b/ghttp/CMakeLists.txt
@@ -1,5 +1,13 @@
 cmake_minimum_required(VERSION 3.0.0)
 
+if (RS_OPENSSL)
+	find_package(OpenSSL COMPONENTS SSL)
+
+    if (NOT OPENSSL_FOUND)
+        message(STATUS "Failed to find OpenSSL libraries, falling back to built in SSL.")
+    endif()
+endif()
+
 add_library(rshttp
     ghttpBuffer.c
     ghttpCallbacks.c
@@ -21,6 +29,11 @@ endif()
 # Extended log for HTTP
 if (CMAKE_BUILD_TYPE EQUAL "DEBUG")
 	target_compile_definitions(rshttp PUBLIC GHTTP_EXTENDEDERROR=1)
+endif()
+
+if (OPENSSL_FOUND)
+    target_link_libraries(rshttp OpenSSL::SSL)
+    target_compile_definitions(rshttp PRIVATE OPENSSL=1)
 endif()
 
 if(RS_BUILD_TESTS)

--- a/ghttp/ghttp.h
+++ b/ghttp/ghttp.h
@@ -115,6 +115,7 @@ typedef enum
 	GHTTPEncryptionEngine_GameSpy,   // must add /common/gsSSL.h and /common/gsSSL.c to project
 	GHTTPEncryptionEngine_MatrixSsl, // must define MATRIXSSL and include matrixssl source files
 	GHTTPEncryptionEngine_RevoEx,    // must define REVOEXSSL and include RevoEX SSL source files
+	GHTTPEncryptionEngine_OpenSsl,   // must define OPENSSL and include OpenSSL source files
 	
 	GHTTPEncryptionEngine_Default    // Will use GameSpy unless another engine is defined
 	                                 //   using MATRIXSSL or REVOEXSSL


### PR DESCRIPTION
Enables libgsm for the voice2bench test program and moves openssl detection to the http module where it is exclusively required.